### PR TITLE
[ITA-115] Cancel previous build - ClassCastException fix

### DIFF
--- a/vars/cancelPreviousBuilds.groovy
+++ b/vars/cancelPreviousBuilds.groovy
@@ -17,12 +17,7 @@ def call() {
     def exec = build.getExecutor()
 
     if (build.number != currentBuild.number && exec != null) {
-      exec.interrupt(
-        Result.ABORTED,
-        new CauseOfInterruption.UserInterruption(
-          "Aborted by #${currentBuild.number}"
-        )
-      )
+      exec.doStop()
       println("Aborted previous running build #${build.number}")
     } else {
       println("Build is not running or is current build, not aborting - #${build.number}")

--- a/vars/withCustomCommitStates.groovy
+++ b/vars/withCustomCommitStates.groovy
@@ -1,0 +1,46 @@
+def call(final TreeMap scmEnv, final String credentialsId, final String context, block) {
+
+  def STATE_NAME_PENDING = 'pending'
+  def STATE_NAME_SUCCESS = 'success'
+  def STATE_NAME_FAILURE = 'failure'
+  def STATE_NAME_ERROR = 'error'
+
+  def STATES = [
+    [state: STATE_NAME_PENDING, description: 'The build is pending'],
+    [state: STATE_NAME_SUCCESS, description: 'This commit looks good'],
+    [state: STATE_NAME_FAILURE, description: 'An error or test failure occurred'],
+    [state: STATE_NAME_ERROR, description: 'This commit cannot be built']
+  ]
+
+  def PENDING_STATE = STATES.find{it['state'] == STATE_NAME_PENDING}
+  def SUCCESS_STATE = STATES.find{it['state'] == STATE_NAME_SUCCESS}
+  def FAILURE_STATE = STATES.find{it['state'] == STATE_NAME_FAILURE}
+
+  def currentState = FAILURE_STATE
+  try {
+    setCommitState(scmEnv, credentialsId, PENDING_STATE['state'], PENDING_STATE['description'], context)
+    block()
+    currentState = SUCCESS_STATE
+  } finally {
+    setCommitState(scmEnv, credentialsId, currentState['state'], currentState['description'], context)
+  }
+}
+
+def setCommitState(final TreeMap scmEnv, final String credentialsId, final String state, final String description, final String context) {
+  withCredentials([string(credentialsId: credentialsId, variable: 'GITHUB_TOKEN')]) {
+
+    def repoName = scm.getUserRemoteConfigs().get(0).getUrl().tokenize('/')[3].split("\\.")[0]
+    def commitSHA = scmEnv['GIT_COMMIT']
+
+    sh """
+      curl -XPOST -H "Authorization: token \${GITHUB_TOKEN}" https://api.github.com/repos/h2oai/${repoName}/statuses/${commitSHA} -d "{
+        \\"state\\": \\"${state}\\",
+        \\"target_url\\": \\"${BUILD_URL}\\",
+        \\"description\\": \\"${description}\\",
+        \\"context\\": \\"${context}\\"
+      }"
+    """
+  }
+}
+
+return this

--- a/vars/withCustomCommitStates.txt
+++ b/vars/withCustomCommitStates.txt
@@ -1,0 +1,22 @@
+# Pipeline withCustomCommitStates step #
+This step allows a pipeline job to set custom GitHub commit states. The states are being updated in following manner:
+
+1. build **pending** - set before starting the build
+2. based on the result, there are two possibilities
+    1. build has been **successful** - set after the build finishes without errors
+    2. build has **failed** - set after the build finishes with errors or if the build does not finish at all (for example errors in Jenkinsfile, connectivity issues, etc.)
+
+## Example ##
+```groovy
+  withCustomCommitStates(scm, <CREDENTIALS_ID>, <CONTEXT>) {
+    node {
+      ...
+    }
+  }
+```
+All arguments are **mandatory**.
+
+|Argument          | Class  | Notes                                                                                            |
+| ---              | ---    | ---                                                                                              |
+| `CREDENTIALS_ID` | String | OAuth token used to set the commit state, credentials are expected to by of type **Secret Text** |
+| `CONTEXT`        | String | The notifications context, GH uses the context to differentiate notifications                    |


### PR DESCRIPTION
Sometimes when cancelling previous build there was following error:
```
hudson.remoting.ProxyException: org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object 'ABORTED' with class 'hudson.model.Result' to class 'jenkins.model.CauseOfInterruption'
```

It looks like this happens when we are about to cancel build waiting for executor. If we use the `exec.doStop()`, everything works fine in this case