### PR TITLE
[ITA-115] Stop previous builds using doStop() method

### DIFF
--- a/vars/cancelPreviousBuilds.groovy
+++ b/vars/cancelPreviousBuilds.groovy
@@ -17,12 +17,7 @@ def call() {
     def exec = build.getExecutor()
 
     if (build.number != currentBuild.number && exec != null) {
-      exec.interrupt(
-        Result.ABORTED,
-        new CauseOfInterruption.UserInterruption(
-          "Aborted by #${currentBuild.number}"
-        )
-      )
+      exec.doStop()
       println("Aborted previous running build #${build.number}")
     } else {
       println("Build is not running or is current build, not aborting - #${build.number}")


### PR DESCRIPTION
Sometimes when cancelling previous build there was following error:
```
hudson.remoting.ProxyException: org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object 'ABORTED' with class 'hudson.model.Result' to class 'jenkins.model.CauseOfInterruption'
```

It looks like this happens when we are about to cancel build waiting for executor. If we use the `exec.doStop()`, everything works fine in this case