### PR TITLE
Nonlocal version

### DIFF
--- a/src/ai/h2o/ci/BuildInfo.groovy
+++ b/src/ai/h2o/ci/BuildInfo.groovy
@@ -47,6 +47,10 @@ class BuildInfo implements Serializable {
         return fragmentVersion(version)[1]
     }
 
+    def getNonLocalVersion() {
+        return nonLocalVersion(version)
+    }
+
     def setVersion(String version) {
         this.version = version
     }
@@ -87,6 +91,19 @@ class BuildInfo implements Serializable {
         def versionRgx = /($xyPartRgx).($zPartRgx)/
         def matcher = (version =~ versionRgx)
         return new Tuple(matcher[0][1], matcher[0][2])
+    }
+
+    /**
+     * Version is given as X.Y.Z+local_version
+     * It returns the X.Y.Z part
+     */
+    @NonCPS
+    def nonLocalVersion(String version) {
+        def xyzPartRgx = /\d+.\d+.\d+/
+        def localPartRgx = /*/
+        def versionRgx = /($xyzPartRgx)+($localPartRgx)/
+        def matcher = (version =~ versionRgx)
+        return matcher[0][1]
     }
 
     @Override


### PR DESCRIPTION
Since some versions can have [local version](https://www.python.org/dev/peps/pep-0440/#local-version-identifiers) portion, it would be nice to have a method that could return the X.Y.Z part without it.

For example because I want to upload my bleeding edge artifacts to `s3://bucket/1.0.0/artifact-1.0.0+dev.1` not `s3://bucket/1.0.0+dev.1/artifact-1.0.0+dev.1`

Does this make sense?