### PR TITLE
Option to specify URL which is opened after click on name of the stage.

### DIFF
--- a/vars/buildSummary.groovy
+++ b/vars/buildSummary.groovy
@@ -28,3 +28,11 @@ def stageWithSummary(final String name, final Closure body) {
 def refreshStage(final String name, final boolean resetTimer = true) {
     _buildSummary.getStagesSummary().setStageDetails(this, name, resetTimer)
 }
+
+def setStageUrl(final String name) {
+    _buildSummary.getStagesSummary().setStageUrl(this, name, null)
+}
+
+def setStageUrl(final String name, final String url) {
+    _buildSummary.getStagesSummary().setStageUrl(this, name, url)
+}


### PR DESCRIPTION
Very simple implementation. Makes possible to specify URL which is opened after user clicks on the stage name in Stages Overview.

The URL needs workflow node id. This is how that id is found:
- find node with display name equal to the stage name, let's call this the initial node
- traverse parents
- if there is a parent whose display name starts with `Branch: `, use id of this node
- if there is no such parent, use id of the initial node

**THIS IS HIGHLY EXPERIMENTAL**