### PR TITLE
Tiny improvement to show result in textual form instead of icon.

### DIFF
--- a/src/ai/h2o/ci/BuildResult.groovy
+++ b/src/ai/h2o/ci/BuildResult.groovy
@@ -22,7 +22,7 @@ enum BuildResult {
      * Indicates that stage has been successful HOWEVER the result needs attention.
      * For example the benchmarks are not in an expected interval/
      */
-    WARNING('Warning', 'red.gif')
+    WARNING('Warning', 'warning.gif')
 
     private final String text
     private final String imageName

--- a/src/ai/h2o/ci/buildsummary/StagesSummary.groovy
+++ b/src/ai/h2o/ci/buildsummary/StagesSummary.groovy
@@ -125,7 +125,7 @@ class StagesSummary extends SummaryInfo {
             final BuildResult result = stageSummary.getResult() ?: BuildResult.PENDING
             stagesTableBody += """
                 <tr>
-                    <td style="${TD_STYLE}"><img src="${result.getImageUrl(context, BuildSummaryUtils.ImageSize.LARGE)}" /></td>
+                    <td style="${TD_STYLE}"><img src="${result.getImageUrl(context, BuildSummaryUtils.ImageSize.LARGE)}" alt="${result.getText()}"/></td>
                     <td style="${TD_STYLE}">${stageSummary.getNameForOverview()}</td>
                     <td style="${TD_STYLE}">${stageSummary.getNodeNameText()}</td>
                     <td style="${TD_STYLE}">${stageSummary.getWorkspaceText()}</td>


### PR DESCRIPTION
The summary email references icons provided by internal jenkins.
This change just provide `alt` attribute for img tag describing result.

TODO:
  - [ ] Mark stages which ware aborted 
  - [ ] Mark stages which fails on non-test failure